### PR TITLE
Changes to run loadtest on D6 w/ Tag1 VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Assumptions
 These scripts assume:
  1.  A Drupal installation -- webroot and database.
  2.  [Apache Jmeter](http://jmeter.apache.org/) installed to /usr/local/jmeter/
+ 3.  This repo was checked out at /root and renamed to jmeter
 
 Running Tests
 -------------

--- a/loadtest.jmx
+++ b/loadtest.jmx
@@ -35,7 +35,7 @@
           </elementProp>
           <elementProp name="drupal.path.logout" elementType="Argument">
             <stringProp name="Argument.name">drupal.path.logout</stringProp>
-            <stringProp name="Argument.value">user/logout</stringProp>
+            <stringProp name="Argument.value">logout</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="drupal.password" elementType="Argument">
@@ -1322,7 +1322,7 @@
         </hashTree>
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="logout" enabled="true"/>
         <hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="user/logout" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="logout" enabled="true">
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
               <collectionProp name="Arguments.arguments"/>
             </elementProp>
@@ -1619,7 +1619,7 @@
         </hashTree>
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="logout" enabled="true"/>
         <hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="user/logout" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="logout" enabled="true">
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
               <collectionProp name="Arguments.arguments"/>
             </elementProp>

--- a/scripts/memcache.settings.inc
+++ b/scripts/memcache.settings.inc
@@ -1,9 +1,7 @@
 
 // Memcached settings.
-$conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
+$conf['cache_inc'] ='sites/all/modules/memcache/memcache.inc';
 $conf['lock_inc'] = 'sites/all/modules/memcache/memcache-lock.inc';
 $conf['memcache_stampede_protection'] = TRUE;
-$conf['cache_default_class'] = 'MemCacheDrupal';
-
-// The 'cache_form' bin must be assigned no non-volatile storage.
-$conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+// The 'cache_form' bin must be assigned to non-volatile storage.
+$conf['memcache_bins']['cache_form'] = 'database';

--- a/scripts/preptest.sh
+++ b/scripts/preptest.sh
@@ -3,10 +3,10 @@
 # Prep a base Drupal install for memcache testing.
 # This assumes that $WEBDIR contains a working Drupal install.
 
-WEBDIR=/var/www/html
+WEBDIR=/var/www/vagrant-multi1.tag1consulting.com
 MEMCACHE_SETTINGS_FILE=memcache.settings.inc
-MEMCACHE_VERSION=7.x-1.2
-DATABASE_NAME=drupal
+MEMCACHE_VERSION=6.x-1.11-rc1
+DATABASE_NAME=vagrant
 
 USER_COUNT=5000
 CONTENT_COUNT=10000

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -11,14 +11,14 @@ fi
 
 DATE=`date +%d-%m-%y--%H:%M:%S-$TAG`
 BASEDIR="/root/jmeter"
-WEBROOT="/var/www/html"
+WEBROOT="/var/www/vagrant-multi1.tag1consulting.com"
 OUTPUT="$BASEDIR/output"
 DEST="$WEBROOT/$DATE"
 SECONDS=300
 IPADDR=$(/sbin/ifconfig eth0 | /bin/grep 'inet addr' | /bin/cut -d':' -f 2 | /bin/cut -d' ' -f 1)
 # This is output by preptest.sh...
 SQL_DUMP=/root/drupal_with_test_content.sql.gz
-DB_NAME=drupal
+DB_NAME=vagrant
 
 # Load the database into MySQL so each test starts with the same base data.
 echo "Reloading DB, this will likely take a few minutes..."
@@ -26,7 +26,7 @@ mysql -e "DROP DATABASE $DB_NAME"
 mysql -e "CREATE DATABASE $DB_NAME"
 gunzip -c $SQL_DUMP | mysql $DB_NAME
 
-/sbin/service mysqld restart
+/sbin/service mariadb restart
 /sbin/service httpd restart
 /sbin/service memcached restart
 
@@ -37,7 +37,7 @@ rm -f "$WEBROOT/latest"
 ln -s $DEST "$WEBROOT/latest"
 # Add .htaccess to override Drupal's default of disabling indexes.
 echo "Options +Indexes" > $WEBROOT/latest/.htaccess
-echo 'stats' | nc localhost 11211 > "$WEBROOT/latest/memcached.stats.txt"
+echo 'stats' | nc 127.0.0.1 11211 > "$WEBROOT/latest/memcached.stats.txt"
 
 SUMMARY="$WEBROOT/latest/summary.tsv"
 


### PR DESCRIPTION
These are the changes I had to make to get our loadtest working with a Drupal 6
website for testing 6.x-1.11-rc1.
